### PR TITLE
Changed corruption system to soft delete entities, and other curruption changes

### DIFF
--- a/Content.Shared/SS220/CultYogg/Components/CultYoggCorruptedComponent.cs
+++ b/Content.Shared/SS220/CultYogg/Components/CultYoggCorruptedComponent.cs
@@ -13,14 +13,21 @@ public sealed partial class CultYoggCorruptedComponent : Component
 {
     /// <summary>
     /// Prototype ID of the original entity, <see langword="null"/> if none.
-    /// Note that this field is required to reverse corruption.
+    /// This field is used to reverse corruption if <see cref="SoftDeletedOriginalEntity"/> is not set.
     /// </summary>
     [DataField]
     public ProtoId<EntityPrototype>? OriginalPrototypeId;
+
     /// <summary>
     /// Prototype ID of the corruption recipe used to currupt entity, <see langword="null"/> if none.
-    /// Note that this field is required to reverse corruption.
+    /// This field is required to reverse corruption.
     /// </summary>
     [DataField]
     public ProtoId<CultYoggCorruptedPrototype>? Recipe;
+
+    /// <summary>
+    /// If corruption happend in runtime, entity got "soft deleted, this is its uid.
+    /// This field is used to reverse corruption, <see cref="OriginalPrototypeId"/> will be used if <see langword="null"/>.
+    /// </summary>
+    public EntityUid? SoftDeletedOriginalEntity;
 }

--- a/Content.Shared/SS220/CultYogg/CultYoggCorruptedPrototype.cs
+++ b/Content.Shared/SS220/CultYogg/CultYoggCorruptedPrototype.cs
@@ -1,5 +1,6 @@
 // © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
 using Content.Shared.Stacks;
+using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
@@ -39,6 +40,8 @@ namespace Content.Shared.SS220.CultYogg
     [Serializable, NetSerializable]
     public partial struct CorruptionInitialEntityUnion
     {
+        // The properties here are arranged in descending order of priority, so the first one will be checked first. 
+
         /// <summary>
         /// Defines that source entity should be spawned from specified prototype id 
         /// </summary>
@@ -50,5 +53,17 @@ namespace Content.Shared.SS220.CultYogg
         /// </summary>
         [DataField("stackType")]
         public ProtoId<StackPrototype>? StackType { get; private set; }
+
+        /// <summary>
+        /// Defines that source entity should be spawned from prototype, inheriting the prototype with specified id 
+        /// </summary>
+        [DataField("parentPrototypeId")]
+        public ProtoId<EntityPrototype>? ParentPrototypeId { get; private set; }
+
+        /// <summary>
+        /// Defines that source entity should be tagged with specified tag
+        /// </summary>
+        [DataField("tag")]
+        public ProtoId<TagPrototype>? Tag { get; private set; }
     }
 }

--- a/Content.Shared/SS220/SoftDelete/SharedSoftDeleteSystem.cs
+++ b/Content.Shared/SS220/SoftDelete/SharedSoftDeleteSystem.cs
@@ -1,0 +1,86 @@
+// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
+using Content.Shared.GameTicking;
+using Robust.Shared.Map;
+
+namespace Content.Shared.SS220.SoftDelete;
+
+/// <summary>
+/// Allows to fully disable an entity without completely deleting it, and then restore it back.
+/// </summary>
+public sealed class SharedSoftDeleteSystem : EntitySystem
+{
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+
+    private EntityUid? PausedMap { get; set; }
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    public bool IsSoftDeleted(Entity<TransformComponent?> entity)
+    {
+        var (_, comp) = entity;
+        comp ??= Transform(entity);
+
+        return comp.MapUid != null && comp.MapUid == PausedMap;
+    }
+
+    public void SoftDelete(EntityUid entity)
+    {
+        EnsurePausedMap();
+        if (PausedMap is not { } pausedMap)
+        {
+            Log.Error("Soft delete map was unexpectedly null");
+            return;
+        }
+        var transform = Transform(entity);
+        if (IsSoftDeleted((entity, transform)))
+            return;
+        var parent = _transformSystem.GetParentUid(entity);
+        var softDeletedComp = EnsureComp<SoftDeletedComponent>(entity);
+        softDeletedComp.ActualParent = parent;
+        _transformSystem.SetParent(entity, transform, pausedMap);
+        DirtyEntity(entity);
+    }
+
+    public bool TryRestore(EntityUid entity)
+    {
+        var transform = Transform(entity);
+        if (!IsSoftDeleted((entity, transform)))
+            return false;
+        if (!TryComp<SoftDeletedComponent>(entity, out var softDeletedComp))
+        {
+            Log.Error($"Expected {nameof(SoftDeletedComponent)} on soft deleted entity, found null");
+            return false;
+        }
+        _transformSystem.SetParent(entity, transform, softDeletedComp.ActualParent);
+        RemComp(entity, softDeletedComp);
+        return true;
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent _)
+    {
+        DeletePausedMap();
+    }
+
+    private void DeletePausedMap()
+    {
+        if (PausedMap == null || !Exists(PausedMap))
+            return;
+
+        EntityManager.DeleteEntity(PausedMap.Value);
+        PausedMap = null;
+    }
+
+    private void EnsurePausedMap()
+    {
+        if (PausedMap != null && Exists(PausedMap))
+            return;
+
+        PausedMap = _mapSystem.CreateMap(out var mapId);
+        _mapManager.SetMapPaused(mapId, true);
+    }
+}

--- a/Content.Shared/SS220/SoftDelete/SoftDeletedComponent.cs
+++ b/Content.Shared/SS220/SoftDelete/SoftDeletedComponent.cs
@@ -1,0 +1,8 @@
+// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
+namespace Content.Shared.SS220.SoftDelete;
+
+[RegisterComponent]
+public sealed partial class SoftDeletedComponent : Component
+{
+    public EntityUid ActualParent;
+}


### PR DESCRIPTION
## Описание PR

- Теперь при коррапте энтити не удаляется, а "выключается" (назвал "soft delete", система для этого общая и может использовать для других вещей), при раскоррапчивании возвращается в прежнем виде
- В прототипы корраптов добавлены способы коррапта по родительскому прототипу и тегу
- Пофикшены некоторые баги коррапта (коррапт контейнера в руке, раскоррапт в контейнере)

**Медиа**

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
